### PR TITLE
upgrade to ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q
 RUN apt install -y -q \
     build-essential \
     clang \
-    cmake \
     curl \
     gcc \
     gettext \
@@ -26,7 +25,10 @@ RUN apt install -y -q \
     ninja-build \
     xz-utils \
     zlib1g-dev
- 
+
+RUN curl -sL https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-Linux-x86_64.tar.gz |\
+    tar zxvf - -C /usr --strip-components=1
+
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     echo "LANG=en_US.UTF-8" > /etc/locale.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q


### PR DESCRIPTION
builds are failing for 3 weeks due to cmake 20 requirement: https://github.com/compiler-explorer/compiler-workflows/actions/workflows/build-daily-dotnet.yml. instead of just upgrading the cmake, i went with ubuntu 22.04 upgrade which has cmake 3.22.1.