### PR TITLE
skip checked build for .net 7+

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -4,11 +4,13 @@ set -ex
 
 VERSION=$1
 OS=linux
+TIMESTAMP="$(date +%Y%m%d)"
 if echo "${VERSION}" | grep -q 'trunk'; then
-    VERSION=trunk-$(date +%Y%m%d)
+    VERSION=trunk-"$TIMESTAMP"
     BRANCH=main
 else
     BRANCH="${VERSION}"
+    VERSION_WITHOUT_V="${VERSION:1}"
     if [[ "${VERSION:1:1}" -lt 8 ]]; then OS=Linux; fi
     if [[ "${VERSION:1:1}" -lt 7 ]]; then CHECKED_BUILD_NEEDED=1; fi
 fi
@@ -38,17 +40,17 @@ cd ${DIR}
 commit="$(git rev-parse HEAD)"
 echo "HEAD is at: $commit"
 
-CORE_ROOT=artifacts/tests/coreclr/"${OS}".x64.Release/Tests/Core_Root
+CORE_ROOT="$(pwd)"/artifacts/tests/coreclr/"${OS}".x64.Release/Tests/Core_Root
 
 if [[ "$CHECKED_BUILD_NEEDED" -eq 1 ]]; then
   # Build everything in Release mode
-  ./build.sh Clr+Libs -c Release --ninja -ci -p:OfficialBuildId=$(date +%Y%m%d)-99
+  ./build.sh Clr+Libs -c Release --ninja -ci -p:OfficialBuildId="$TIMESTAMP"-99
 
   # Build Checked JIT compilers (only Checked JITs are able to print codegen)
   ./build.sh Clr.AllJits -c Checked --ninja
 else
   # Build everything in Release mode
-  ./build.sh Clr+Clr.Aot+Libs -c Release --ninja -ci -p:OfficialBuildId=$(date +%Y%m%d)-99
+  ./build.sh Clr+Clr.Aot+Libs -c Release --ninja -ci -p:OfficialBuildId="$TIMESTAMP"-99
 fi
 
 cd src/tests
@@ -57,13 +59,37 @@ cd src/tests
 ./build.sh Release generatelayoutonly
 cd ../..
 
-# Write version info for .NET 6 (it doesn't have crossgen2 --version)
-echo "${VERSION:1}+${commit}" > ${CORE_ROOT}/version.txt
-
 if [[ "$CHECKED_BUILD_NEEDED" -eq 1 ]]; then
+  # Write version info for .NET 6 (it doesn't have crossgen2 --version)
+  echo "${VERSION_WITHOUT_V}+${commit}" > ${CORE_ROOT}/version.txt
+
   # Copy Checked JITs to CORE_ROOT
   cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"
   cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"/crossgen2
+else
+  # For .NET 7 and above, copy nativeaot files at CORE_ROOT/aot
+  # later we can use `dotnet publish -p:PublishAot=true --packages "${CORE_ROOT}"/aot`
+  ./dotnet.sh build -c Release -p:ContinuousIntegrationBuild=true -p:OfficialBuildId="$TIMESTAMP"-99 \
+      src/installer/pkg/projects/nativeaot-packages.proj
+
+  mkdir "${CORE_ROOT}"/aot
+  if [[ "$BRANCH" == "main" ]]; then
+    ILC="$(find artifacts/bin -type f -name ilc | head -1)"
+    PACKAGE_VERSION="$("${ILC}" --version)"
+  else
+    PACKAGE_VERSION="$VERSION_WITHOUT_V"
+  fi
+
+  echo "$PACKAGE_VERSION" > "${CORE_ROOT}"/aot/package-version.txt
+  cp artifacts/packages/Release/Shipping/*ILCompiler*.nupkg "${CORE_ROOT}"/aot
+
+  # initialize AOT packages directory
+  pushd /tmp
+  "${DIR}/dotnet.sh" new console -o app
+  "${DIR}/dotnet.sh" add app package "Microsoft.DotNet.ILCompiler" --version "$PACKAGE_VERSION" --package-directory "${CORE_ROOT}"/aot -s "${CORE_ROOT}"/aot
+  "${DIR}/dotnet.sh" add app package "runtime.linux-x64.microsoft.dotnet.ilcompiler" --version "$PACKAGE_VERSION" --package-directory "${CORE_ROOT}"/aot -s "${CORE_ROOT}"/aot
+  "${DIR}/dotnet.sh" publish -p:PublishAot=true --packages "${CORE_ROOT}"/aot app
+  popd
 fi
 
 # Copy the bootstrapping .NET SDK, needed for 'dotnet build'


### PR DESCRIPTION
a separate checked build for altjits was only needed up until .net 6.
starting from .net 7, `clr.aot` builds altjits in release mode and support diff options.

https://github.com/dotnet/runtime/pull/73365