### PR TITLE
Build a DisassemblyLoader for corerun

### DIFF
--- a/build/DisassemblyLoader/DisassemblyLoader.csproj
+++ b/build/DisassemblyLoader/DisassemblyLoader.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/build/DisassemblyLoader/Program.cs
+++ b/build/DisassemblyLoader/Program.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) 2023, Compiler Explorer Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+//     * Redistributions of source code must retain the above copyright notice,
+//       this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+//       notice, this list of conditions and the following disclaimer in the
+//       documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace CompilerExplorer
+{
+    namespace DisassemblyLoader
+    {
+        class Program
+        {
+            static void Main(string[] args)
+            {
+                var assembly = Assembly.LoadFile(args[0]);
+
+                foreach (var type in assembly.GetTypes())
+                {
+                    ProcessType(type);
+                }
+            }
+
+            static void ProcessType(Type type)
+            {
+                if (type.IsGenericTypeDefinition)
+                {
+                    foreach (var attr in type.GetCustomAttributes<GenericArgumentsAttribute>())
+                    {
+                        try
+                        {
+                            PrepareType(type.MakeGenericType(attr.GenericArguments));
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                    }
+                }
+                else
+                {
+                    PrepareType(type);
+                }
+            }
+
+            static void PrepareType(Type type)
+            {
+                if (type.TypeInitializer is ConstructorInfo initializer)
+                    RuntimeHelpers.PrepareMethod(initializer.MethodHandle);
+
+                foreach (var method in type.GetRuntimeMethods())
+                {
+                    ProcessMethod(method);
+                }
+            }
+
+            static void ProcessMethod(MethodInfo method)
+            {
+                if (method.IsGenericMethodDefinition)
+                {
+                    foreach (var attr in method.GetCustomAttributes<GenericArgumentsAttribute>())
+                    {
+                        try
+                        {
+                            PrepareMethod(method.MakeGenericMethod(attr.GenericArguments));
+                        }
+                        catch
+                        {
+                            continue;
+                        }
+                    }
+                }
+                else
+                {
+                    PrepareMethod(method);
+                }
+            }
+
+            static void PrepareMethod(MethodInfo method)
+            {
+                RuntimeHelpers.PrepareMethod(method.MethodHandle);
+            }
+        }
+    }
+
+    [AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    public sealed class GenericArgumentsAttribute : Attribute
+    {
+        public GenericArgumentsAttribute(params Type[] genericArguments)
+        {
+            GenericArguments = genericArguments;
+        }
+
+        public Type[] GenericArguments { get; }
+    }
+}

--- a/build/build.sh
+++ b/build/build.sh
@@ -94,12 +94,15 @@ else
   popd
 fi
 
+cd "${DIR}"
+
+# Build DisassemblyLoader
+.dotnet/dotnet build -c Release /root/DisassemblyLoader/DisassemblyLoader.csproj -o "${CORE_ROOT}"/DisassemblyLoader
+
 # Copy the bootstrapping .NET SDK, needed for 'dotnet build'
 # Exclude the pdbs as when they are present, when running on Linux we get:
 # Error: Image is either too small or contains an invalid byte offset or count.
 # System.BadImageFormatException: Image is either too small or contains an invalid byte offset or count.
-
-cd "${DIR}"
 mv .dotnet/ "${CORE_ROOT}"/
 cd "${CORE_ROOT}"/..
 XZ_OPT=-2 tar Jcf "${OUTPUT}" --exclude \*.pdb --transform "s,^./,./dotnet-${VERSION}/," -C Core_Root .

--- a/build/build.sh
+++ b/build/build.sh
@@ -97,7 +97,7 @@ fi
 cd "${DIR}"
 
 # Build DisassemblyLoader
-.dotnet/dotnet build -c Release /root/DisassemblyLoader/DisassemblyLoader.csproj -o "${CORE_ROOT}"/DisassemblyLoader
+./.dotnet/dotnet build -c Release /root/DisassemblyLoader/DisassemblyLoader.csproj -o "${CORE_ROOT}"/DisassemblyLoader
 
 # Copy the bootstrapping .NET SDK, needed for 'dotnet build'
 # Exclude the pdbs as when they are present, when running on Linux we get:

--- a/build/build.sh
+++ b/build/build.sh
@@ -5,7 +5,7 @@ set -exu
 VERSION=$1
 OS=linux
 TIMESTAMP="$(date +%Y%m%d)"
-CHECKED_BUILD_NEEDED=0
+AOT_BUILD_NEEDED=0
 
 if echo "${VERSION}" | grep -q 'trunk'; then
     VERSION=trunk-"$TIMESTAMP"
@@ -14,7 +14,7 @@ else
     BRANCH="${VERSION}"
     VERSION_WITHOUT_V="${VERSION:1}"
     if [[ "${VERSION:1:1}" -lt 8 ]]; then OS=Linux; fi
-    if [[ "${VERSION:1:1}" -lt 7 ]]; then CHECKED_BUILD_NEEDED=1; fi
+    if [[ "${VERSION:1:1}" -ge 7 ]]; then AOT_BUILD_NEEDED=1; fi
 fi
 
 URL=https://github.com/dotnet/runtime.git
@@ -44,16 +44,15 @@ echo "HEAD is at: $commit"
 
 CORE_ROOT="$(pwd)"/artifacts/tests/coreclr/"${OS}".x64.Release/Tests/Core_Root
 
-if [[ "$CHECKED_BUILD_NEEDED" -eq 1 ]]; then
-  # Build everything in Release mode
-  ./build.sh Clr+Libs -c Release --ninja -ci -p:OfficialBuildId="$TIMESTAMP"-99
-
-  # Build Checked JIT compilers (only Checked JITs are able to print codegen)
-  ./build.sh Clr.AllJits -c Checked --ninja
-else
-  # Build everything in Release mode
+# Build everything in Release mode
+if [[ "$AOT_BUILD_NEEDED" -eq 1 ]]; then
   ./build.sh Clr+Clr.Aot+Libs -c Release --ninja -ci -p:OfficialBuildId="$TIMESTAMP"-99
+else
+  ./build.sh Clr+Libs -c Release --ninja -ci -p:OfficialBuildId="$TIMESTAMP"-99
 fi
+
+# Build Checked JIT compilers (only Checked JITs are able to filter assembly for printing codegen)
+./build.sh Clr.AllJits -c Checked --ninja
 
 cd src/tests
 
@@ -61,14 +60,13 @@ cd src/tests
 ./build.sh Release generatelayoutonly
 cd ../..
 
-if [[ "$CHECKED_BUILD_NEEDED" -eq 1 ]]; then
-  # Write version info for .NET 6 (it doesn't have crossgen2 --version)
-  echo "${VERSION_WITHOUT_V}+${commit}" > "${CORE_ROOT}"/version.txt
+echo "${VERSION_WITHOUT_V}+${commit}" > "${CORE_ROOT}"/version.txt
 
-  # Copy Checked JITs to CORE_ROOT
-  cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"
-  cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"/crossgen2
-else
+# Copy Checked JITs to CORE_ROOT
+cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"
+cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"/crossgen2
+
+if [[ "$AOT_BUILD_NEEDED" -eq 1 ]]; then
   # For .NET 7 and above, copy nativeaot files at CORE_ROOT/aot
   # later we can use `dotnet publish -p:PublishAot=true --packages "${CORE_ROOT}"/aot`
   ./dotnet.sh build -c Release -p:ContinuousIntegrationBuild=true -p:OfficialBuildId="$TIMESTAMP"-99 \


### PR DESCRIPTION
This DisassemblyLoader will be used for loading all methods in an assembly, so we can view disassembly code produced by corerun instead of crossgen2.