### PR TITLE
Unify constructor handling

### DIFF
--- a/build/DisassemblyLoader/Program.cs
+++ b/build/DisassemblyLoader/Program.cs
@@ -66,10 +66,7 @@ namespace CompilerExplorer
 
             static void PrepareType(Type type)
             {
-                if (type.TypeInitializer is ConstructorInfo initializer)
-                    RuntimeHelpers.PrepareMethod(initializer.MethodHandle);
-
-                foreach (var constructor in type.GetConstructors())
+                foreach (var constructor in type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
                 {
                     RuntimeHelpers.PrepareMethod(constructor.MethodHandle);
                 }


### PR DESCRIPTION
Unify how we handle constructors, which enables us to disassemble constructors in a more reliable way.
I would like to request a rebuild of the image.

/cc: @mattgodbolt 