### PR TITLE
Disable AOT build for trunk

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -11,7 +11,6 @@ if echo "${VERSION}" | grep -q 'trunk'; then
     VERSION=trunk-"$TIMESTAMP"
     BRANCH=main
     VERSION_WITHOUT_V="${VERSION}"
-    AOT_BUILD_NEEDED=1
 else
     BRANCH="${VERSION}"
     VERSION_WITHOUT_V="${VERSION:1}"


### PR DESCRIPTION
It's never working for trunk and causing the daily build to fail.
Even if it was built successfully, it still won't work on the compiler-explorer.

Example: https://godbolt.org/z/1dxPoj9vP

/cc: @mattgodbolt 