### PR TITLE
disable aot + create fsharp app to populate cache

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -17,7 +17,7 @@ else
     VERSION_WITHOUT_V="${VERSION:1}"
     MAJOR_VERSION="${VERSION_WITHOUT_V%%.*}"
     if [[ "${MAJOR_VERSION}" -lt 8 ]]; then OS=Linux; fi
-    if [[ "${MAJOR_VERSION}" -ge 7 ]]; then AOT_BUILD_NEEDED=1; fi
+    if [[ "${MAJOR_VERSION}" -ge 7 ]]; then AOT_BUILD_NEEDED=0; fi
 fi
 
 URL=https://github.com/dotnet/runtime.git
@@ -100,6 +100,12 @@ if [[ "$AOT_BUILD_NEEDED" -eq 1 ]]; then
 
   popd
 fi
+
+# create an empty F# app so the fsharp core library is downloaded from nuget
+pushd /tmp
+"${DIR}/dotnet.sh" new console -lang F# -o app
+"${DIR}/dotnet.sh" publish app
+popd
 
 cd "${DIR}"
 


### PR DESCRIPTION
1. Disables AOT, as I can't figure out myself why the steps are failing (disabling passing versions helps somewhat, but at the publish step it still complains about AspNetCore not being available, when I try a fixed version for ubuntu instead of manually build one the command line works fine, so it's something that's either a bug in some versions or we're not building + setting it up correctly) (see https://github.com/compiler-explorer/dotnet-builder/issues/12)

2. Builds a F# application to download the runtime.

I have not tested if the FSharp.Core.dll shows up in the nuget packages, as it takes ages to build the compiler and I've already done it way too many times trying to get AOT working.

Todo:
* [ ] Check if .tar.xz contains the right files to support FSharp out of the box
