### PR TITLE
Ignore exceptions in PrepareMethod

### DIFF
--- a/build/DisassemblyLoader/Program.cs
+++ b/build/DisassemblyLoader/Program.cs
@@ -68,7 +68,14 @@ namespace CompilerExplorer
             {
                 foreach (var constructor in type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static))
                 {
-                    RuntimeHelpers.PrepareMethod(constructor.MethodHandle);
+                    try
+                    {
+                        RuntimeHelpers.PrepareMethod(constructor.MethodHandle);
+                    }
+                    catch
+                    {
+                        continue;
+                    }
                 }
 
                 foreach (var method in type.GetRuntimeMethods())
@@ -101,7 +108,14 @@ namespace CompilerExplorer
 
             static void PrepareMethod(MethodInfo method)
             {
-                RuntimeHelpers.PrepareMethod(method.MethodHandle);
+                try
+                {
+                    RuntimeHelpers.PrepareMethod(method.MethodHandle);
+                }
+                catch
+                {
+                    // ignored
+                }
             }
         }
     }


### PR DESCRIPTION
An exception can happen in `PrepareMethod` and cause the whole disasm process to fail.
Catch the exception and continue to disasm other methods.