### PR TITLE
Copy checked jit to NativeAOT compiler

### DIFF
--- a/build/DisassemblyLoader/MonoJitInspector.cs
+++ b/build/DisassemblyLoader/MonoJitInspector.cs
@@ -70,7 +70,7 @@ namespace CompilerExplorer
                 ulong tail = (ulong)(code + size);
                 var methodName = FormatMethodName(method);
 
-                WriteComment(writer, $"Assembly listing for method {methodName}:");
+                WriteComment(writer, $"Assembly listing for method {methodName}");
 
                 while (decoder.IP < tail)
                 {

--- a/build/DisassemblyLoader/Program.cs
+++ b/build/DisassemblyLoader/Program.cs
@@ -134,7 +134,7 @@ namespace CompilerExplorer
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"; Failed to generate code for '{methodBase}':");
+                    Console.WriteLine($"; Failed to generate code for method {methodBase}");
                     foreach (var line in ex.ToString().AsSpan().EnumerateLines())
                     {
                         Console.WriteLine($"; {line}");

--- a/build/build.sh
+++ b/build/build.sh
@@ -68,6 +68,9 @@ echo "${VERSION_WITHOUT_V}+${commit}" > "${CORE_ROOT}"/version.txt
 # Copy Checked JITs to CORE_ROOT
 cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"
 cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"/crossgen2
+if [ -d "${CORE_ROOT}"/ilc-published ]; then
+    cp artifacts/bin/coreclr/"${OS}".x64.Checked/libclrjit*.so "${CORE_ROOT}"/ilc-published
+fi
 
 # Copy mono to CORE_ROOT_MONO
 mkdir -p "${CORE_ROOT_MONO}"


### PR DESCRIPTION
This is a prerequisites of enabling disassembly for NativeAOT. 

@partouf 