### PR TITLE
Minor change to the symbol text format

### DIFF
--- a/build/DisassemblyLoader/MonoJitInspector.cs
+++ b/build/DisassemblyLoader/MonoJitInspector.cs
@@ -146,7 +146,7 @@ namespace CompilerExplorer
                     return false;
                 }
 
-                symbol = new SymbolResult(address, $"{address:X}h ; {(Marshal.PtrToStringAnsi((nint)name) ?? "unknown").Trim()}");
+                symbol = new SymbolResult(address, Marshal.PtrToStringAnsi((nint)name)?.Trim() ?? "unknown");
                 return true;
             }
         }


### PR DESCRIPTION
We may sometimes get assembly like `[rip+40808378h ; Program:.cctor () [{0x5f207e4224e0} + 0x1b8] [/app/example.cs :: 8u] (0x408081c0 0x40808388) [0x5f207e1156d0 - DisassemblyLoader.dll] (40808378h)]`.
where the `]` being placed after the `;` incorrectly.
Change the format to `[rip+Program:.cctor () [{0x5f207e4224e0} + 0x1b8] [/app/example.cs :: 8u] (0x408081c0 0x40808388) [0x5f207e1156d0 - DisassemblyLoader.dll] (40808378h)]` instead.