### PR TITLE
Use OS variable

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -93,7 +93,7 @@ for ARCH in "${CORELIB_ARCHITECTURES[@]}"; do
     cd "${DIR}"
     ./build.sh -s clr.corelib -arch "$ARCH" -c Release
     mkdir "${CORE_ROOT}"/corelib/"$ARCH"
-    cp -r artifacts/bin/coreclr/linux."$ARCH".Release/IL/* "${CORE_ROOT}"/corelib/"$ARCH"
+    cp -r artifacts/bin/coreclr/"${OS}"."$ARCH".Release/IL/* "${CORE_ROOT}"/corelib/"$ARCH"
 done
 
 # Runtime build is done, now build the DisassemblyLoader


### PR DESCRIPTION
A simple fix to avoid potential build failure when build old versions of compiler.