### PR TITLE
Skip cross-build on .NET 9 and earlier

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -23,6 +23,7 @@ else
     if [[ "${MAJOR_VERSION}" -lt 10 ]]; then
         ALL_JITS_SUBSET="Clr.AllJits"
         CORELIB_ARCHITECTURES=("x86" "x64" "arm" "arm64")
+        NATIVEAOT_ARCHITECTURES=("x64")
     fi
     if [[ "${MAJOR_VERSION}" -lt 8 ]]; then
         OS=Linux


### PR DESCRIPTION
This should resolve the build failure of .NET 8 and .NET 9. .NET NativeAOT SDK doesn't support cross build prior to .NET 10.

@mattgodbolt 