### PR TITLE
Update the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM ubuntu:20.04
+FROM ubuntu:26.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q
 RUN apt install -y -q \
     build-essential \
     clang \
+    cmake \
     curl \
     gcc \
     gettext \
@@ -25,9 +26,6 @@ RUN apt install -y -q \
     ninja-build \
     xz-utils \
     zlib1g-dev
-
-RUN curl -sL https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-Linux-x86_64.tar.gz |\
-    tar zxvf - -C /usr --strip-components=1
 
 RUN echo "LC_ALL=en_US.UTF-8" >> /etc/environment && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:26.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update -y -q && apt upgrade -y -q


### PR DESCRIPTION
Updated base image to Ubuntu 24.04 and removed CMake installation from source.

@mattgodbolt Please take a look. I think the dotnet-trunk build has been failed for a month due to clang version being too old.